### PR TITLE
Add Async Support, Job Preservation, and Customizable Collection Names

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,39 +1,47 @@
-// swift-tools-version:5.2
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
     name: "queues-mongo-driver",
     platforms: [
-        .macOS(.v10_15)
+        .macOS(.v13),
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
     ],
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "QueuesMongoDriver",
-            targets: ["QueuesMongoDriver"]),
+        .library(name: "QueuesMongoDriver", targets: ["QueuesMongoDriver"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
-        .package(url: "https://github.com/vapor/queues.git", from: "1.0.0"),
-        .package(url: "https://github.com/OpenKitten/MongoKitten.git", from: "6.5.0")
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.100.0"),
+        .package(url: "https://github.com/vapor/queues.git", from: "1.15.0"),
+        .package(url: "https://github.com/OpenKitten/MongoKitten.git", from: "7.9.5")
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "QueuesMongoDriver",
             dependencies: [
                 .product(name: "Vapor", package: "vapor"),
                 .product(name: "Queues", package: "queues"),
                 .product(name: "MongoKitten", package: "MongoKitten"),
-            ]),
+            ],
+            swiftSettings: swiftSettings
+        ),
         .testTarget(
             name: "QueuesMongoDriverTests",
             dependencies: [
                 .target(name: "QueuesMongoDriver"),
                 .product(name: "XCTVapor", package: "vapor")
-            ])
+            ],
+            swiftSettings: swiftSettings
+        )
     ]
 )
+
+var swiftSettings: [SwiftSetting] { [
+    .enableUpcomingFeature("ForwardTrailingClosures"),
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("ConciseMagicFile"),
+    .enableUpcomingFeature("DisableOutwardActorInference"),
+    .enableExperimentalFeature("StrictConcurrency=complete"),
+] }

--- a/Sources/Documentation.docc/Documentation.md
+++ b/Sources/Documentation.docc/Documentation.md
@@ -1,11 +1,29 @@
-# QueuesMongoDriver
+# ``QueuesMongoDriver``
 
-A driver for [Queues]. Uses [MongoKitten](https://github.com/OpenKitten/MongoKitten) to store job metadata in a MongoDB database.
+@Metadata {
+    @TitleHeading("Package")
+}
+
+A driver for [Queues]. Uses [MongoKitten] to store job metadata in a MongoDB database.
 
 [Queues]: https://github.com/vapor/queues
 [MongoKitten]: https://github.com/OpenKitten/MongoKitten
 
-## Getting Started
+## Overview
+
+This package provides a MongoDB-based driver for Vapor's Queues system, allowing you to store and manage job metadata in a MongoDB database.
+
+## Compatibility
+
+This driver depends on [MongoKitten](https://github.com/OpenKitten/MongoKitten) and is compatible with:
+
+- MongoDB 5.0+
+- Vapor 4.x 
+- Swift 5.9+
+
+## Getting started
+
+#### Adding the dependency
 
 Add `queues-mongo-driver` as dependency to your `Package.swift`:
 ```swift
@@ -26,23 +44,6 @@ targets: [
 ]
 ```
 
-This driver depends on [MongoKitten](https://github.com/OpenKitten/MongoKitten) so to configure the driver we need an instance of a `MongoDatabase`. Ideally during app startup or in your `configure.swift`:
-
-```swift
-import QueuesMongoDriver
-import MongoKitten
-
-func configure(app: Application) throws {
-  let mongoDatabase = try MongoDatabase.lazyConnect(
-    to: "mongodb://localhost:27017/my-database"
-  )
-  
-  // Setup Indexes for the Job Schema for performance (Optional)
-  try app.queues.setupMongo(using: mongoDatabase)
-  app.queues.use(.mongodb(mongoDatabase))
-}
-```
-
 ### Configuration
 
 To configure the MongoDB driver, you'll need a `MongoDatabase` instance:
@@ -58,9 +59,6 @@ try await app.queues.setupMongo(using: database)
 ``` 
 
 This will create the necessary indexes on the MongoDB collection used for storing queue jobs.   
-
-> [!WARNING]
-> Always call `try await app.queues.setupMongo(using: database)` **before** calling `app.queues.use(.mongodb(...))`.
 
 ## Options
 
@@ -92,5 +90,3 @@ The driver creates several indexes on the MongoDB collection to optimize perform
 
 - `job_index` (unique) on `jobid`: This index prevents duplicate jobs from being added to the queue.
 - `queue_index` (unique) on `queue`: This index allows for efficient queue-specific queries.
-
-

--- a/Sources/QueuesMongoDriver/MongoJob.swift
+++ b/Sources/QueuesMongoDriver/MongoJob.swift
@@ -1,0 +1,69 @@
+import struct Foundation.Date
+import struct Foundation.Data
+import struct Queues.JobData
+import struct Queues.JobIdentifier
+import struct Queues.QueueName
+
+/// The state of a job currently stored in the database.
+enum StoredJobState: String, Codable, CaseIterable {
+    /// Job has been set up but is not yet ready to execute.
+    case initial
+    
+    /// Job is ready to be picked up for execution.
+    case pending
+    
+    /// Job is in progress.
+    case processing
+
+    /// Job is completed.
+    ///
+    /// > Note: This state is only used if the driver is configured to preserve completed jobs.
+    case completed
+}
+
+/// Encapsulates a job's metadata and `JobData`.
+struct MongoJob: Codable {
+    
+    /// The queue to which the job was dispatched. Corresponds directly to a `QueueName`.
+    let id: String
+    
+    /// The queue to which the job was dispatched. Corresponds directly to a `QueueName`.
+    let queueName: String
+    
+    /// The name of the job.
+    let jobName: String
+    
+    /// The date this job was queued.
+    let queuedAt: Date
+    
+    /// An optional `Date` before which the job shall not run.
+    let delayUntil: Date?
+    
+    /// The current state of the Job
+    let state: StoredJobState
+    
+    /// The maximum retry count for the job.
+    let maxRetryCount: Int
+    
+    /// The number of attempts made to run the job so far.
+    let attempts: Int
+    
+    /// The job's payload.
+    let payload: Data
+    
+    /// The standard automatic update tracking timestamp.
+    let updatedAt: Date
+    
+    init(id: JobIdentifier, queue: QueueName, jobData: JobData) {
+        self.id = id.string
+        self.queueName = queue.string
+        self.jobName = jobData.jobName
+        self.queuedAt = jobData.queuedAt
+        self.delayUntil = jobData.delayUntil
+        self.state = .pending
+        self.maxRetryCount = jobData.maxRetryCount
+        self.attempts = jobData.attempts ?? 0
+        self.payload = Data(jobData.payload)
+        self.updatedAt = Date()
+    }
+}

--- a/Sources/QueuesMongoDriver/MongoQueue.swift
+++ b/Sources/QueuesMongoDriver/MongoQueue.swift
@@ -1,0 +1,110 @@
+import Queues
+import MongoKitten
+import Vapor
+
+public struct MongoQueue: AsyncQueue, Sendable {
+    
+    public var context: QueueContext
+    let collection: MongoCollection
+    let preservesCompletedJobs: Bool
+    
+    public func get(_ id: JobIdentifier) async throws -> JobData {
+        guard let job = try await collection.findOne(
+            "id" == id.string &&
+            "queueName" == context.queueName.string &&
+            "state" == StoredJobState.processing.rawValue,
+            as: MongoJob.self
+        ) else {
+            throw QueuesMongoError.missingJob(id)
+        }
+        
+        return JobData(
+            payload: [UInt8](job.payload),
+            maxRetryCount: job.maxRetryCount,
+            jobName: job.jobName,
+            delayUntil: job.delayUntil,
+            queuedAt: job.queuedAt,
+            attempts: job.attempts
+        )
+    }
+    
+    public func set(_ id: JobIdentifier, to data: JobData) async throws {
+        let job = MongoJob(id: id, queue: context.queueName, jobData: data)
+        let document = try BSONEncoder().encode(job)
+        try await collection.insert(document)
+    }
+    
+    public func clear(_ id: JobIdentifier) async throws {
+        
+        let query: Document = [
+            "id": id.string,
+            "queueName": context.queueName.string,
+            "state": StoredJobState.processing.rawValue
+        ]
+
+        if preservesCompletedJobs {
+            _ = try await collection.findOneAndUpdate(
+                where: query,
+                to: [
+                    "$set": [
+                        "state": StoredJobState.completed.rawValue,
+                        "updatedAt": Date()
+                    ] as Document
+                ]
+            ).execute()
+        } else {
+            _ = try await collection.deleteOne(where: query)
+        }
+    }
+    
+    public func pop() async throws -> JobIdentifier? {
+        
+        let query = "queueName" == context.queueName.string &&
+            "state" == StoredJobState.pending.rawValue &&
+            ("delayUntil" == nil || "delayUntil" <= Date())
+        
+        let update: Document = [
+            "$set": [
+                "state": StoredJobState.processing.rawValue,
+                "updatedAt": Date()
+            ] as Document,
+            "$inc": ["attempts": 1]
+        ]
+
+        let reply = try await collection.findAndModify(
+            where: query,
+            update: update
+        )
+        .sort(["queuedAt": .ascending])
+        .execute()
+        
+        guard let document = reply.value else {
+            return nil
+        }
+        
+        guard let job = try? BSONDecoder().decode(MongoJob.self, from: document) else {
+            return nil
+        }
+        
+        return JobIdentifier(string: job.id)
+    }
+    
+    public func push(_ id: JobIdentifier) async throws {
+
+        let query = "id" == id.string &&
+            "queueName" == context.queueName.string
+        
+        let update: Document = [
+            "$set": [
+                "state": StoredJobState.pending.rawValue,
+                "updatedAt": Date()
+            ] as Document,
+            "$inc": ["attempts": 1]
+        ]
+        
+        _ = try await collection.findOneAndUpdate(
+            where: [query],
+            to: update
+        ).execute()
+    }
+}

--- a/Sources/QueuesMongoDriver/MongoQueuesDriver.swift
+++ b/Sources/QueuesMongoDriver/MongoQueuesDriver.swift
@@ -1,0 +1,44 @@
+import protocol Queues.QueuesDriver
+import protocol Queues.Queue
+import protocol Queues.AsyncQueue
+import struct Queues.QueueContext
+import struct Queues.JobIdentifier
+import struct Queues.JobData
+import MongoKitten
+
+public struct MongoQueuesDriver: QueuesDriver {
+    let database: MongoDatabase
+    let preservesCompletedJobs: Bool
+    let collectionName: String
+    
+    public init(
+        database: MongoDatabase,
+        preservesCompletedJobs: Bool = false,
+        collectionName: String = "vapor_queues_jobs"
+    ) {
+        self.database = database
+        self.preservesCompletedJobs = preservesCompletedJobs
+        self.collectionName = collectionName
+    }
+    
+    public func makeQueue(with context: QueueContext) -> any Queue {
+        MongoQueue(
+            context: context,
+            collection: database[collectionName],
+            preservesCompletedJobs: preservesCompletedJobs
+        )
+    }
+    
+    public func shutdown() {}
+}
+
+/*private*/ struct FailingQueue: AsyncQueue {
+    let failure: any Error
+    let context: QueueContext
+
+    func get(_: JobIdentifier) async throws -> JobData   { throw self.failure }
+    func set(_: JobIdentifier, to: JobData) async throws { throw self.failure }
+    func clear(_: JobIdentifier) async throws            { throw self.failure }
+    func push(_: JobIdentifier) async throws             { throw self.failure }
+    func pop() async throws -> JobIdentifier?            { throw self.failure }
+}

--- a/Sources/QueuesMongoDriver/Queues.Provider+Mongo.swift
+++ b/Sources/QueuesMongoDriver/Queues.Provider+Mongo.swift
@@ -1,0 +1,37 @@
+import class Vapor.Application
+import Queues
+import MongoKitten
+
+extension Application.Queues.Provider {
+    /// Retrieve a queues provider which specifies use of the MongoDB driver with a given database.
+    ///
+    /// Example usage:
+    ///
+    /// ```swift
+    /// func configure(_ app: Application) async throws {
+    ///     // ...
+    ///     app.databases.use(.mongo(connectionString: "mongodb://localhost:27017/myapp"), as: .mongo)
+    ///     app.queues.use(.mongodb(database))
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - database: A MongoDB database connection to use for job storage.
+    ///   - preservesCompletedJobs: Defaults to `false`. If `true`, completed jobs are marked with a completed
+    ///     state rather than being removed from the database.
+    ///   - collectionName: The name of the MongoDB collection in which jobs data is stored. Defaults to `queues_jobs`.
+    /// - Returns: An appropriately configured provider for `Application.Queues.use(_:)`.
+    public static func mongodb(
+        _ database: MongoDatabase,
+        preservesCompletedJobs: Bool = false,
+        collectionName: String = "vapor_queues_jobs"
+    ) -> Self {
+        .init {
+            $0.queues.use(custom: MongoQueuesDriver(
+                database: database,
+                preservesCompletedJobs: preservesCompletedJobs,
+                collectionName: collectionName
+            ))
+        }
+    }
+}

--- a/Sources/QueuesMongoDriver/Queues.swift
+++ b/Sources/QueuesMongoDriver/Queues.swift
@@ -3,146 +3,33 @@ import MongoKitten
 import Vapor
 
 extension Application.Queues {
-   public func setupMongo(using database: MongoDatabase) throws {
-        // It's perfectly safe to call this without doing any additional checking because MongoDB will handle this for us.
-        // 1. If the collection does not exist yet, mongodb will create one and add the index to it.
-        // 2. If the index already exists on the collection, mongodb will just ignore the command.
+    /// Sets up MongoDB indexes for optimizing queues performance and data management.
+    ///
+    /// This function creates indexes on the MongoDB collection used for storing queue jobs:
+    /// - A unique index on job IDs to prevent duplicates
+    /// - A unique index on queue names for efficient queue-specific queries
+    ///
+    /// Example usage:
+    /// ```swift
+    /// let database = try await MongoDatabase.connect(to: "mongodb://localhost:27017/myapp")
+    /// try await app.queues.setupMongo(using: database)
+    /// ```
+    ///
+    /// - Parameter database: The MongoDB database connection to use for creating indexes
+    /// - Throws: An error if index creation fails
+    public func setupMongo(using database: MongoDatabase) async throws {
+        let collection = database["vapor_queues"]
         
-        var index = CreateIndexes.Index(named: "job_index", keys: ["jobid": 1, "queue": 1])
-        index.unique = true
-        
-        try database["vapor_queue"].createIndexes([index]).wait()
-    }
-}
-
-extension Application.Queues.Provider {
-    public static func mongodb(_ database: MongoDatabase) -> Self {
-        .init {
-            $0.queues.use(custom: MongoQueuesDriver(database: database))
-        }
-    }
-}
-
-enum QueuesMongoError: Error {
-    case missingJob
-}
-
-class MongoQueue: Queue {
-    var context: QueueContext
-    var mongodb: MongoDatabase
-    
-    init(context: QueueContext, mongodb: MongoDatabase) {
-        self.context = context
-        self.mongodb = mongodb
-    }
-    
-    func get(_ id: JobIdentifier) -> EventLoopFuture<JobData> {
-        mongodb["vapor_queue"]
-        .findOne(["jobid": id.string,
-                  "queue": "\(context.queueName.string)",
-                  "status": MongoJobStatus.processing.rawValue])
-        .decode(MongoJob.self)
-        .unwrap(or: QueuesMongoError.missingJob)
-        .map { $0.data }
-    }
-    
-    func set(_ id: JobIdentifier, to data: JobData) -> EventLoopFuture<Void> {
-        do {
-            let encoded = try BSONEncoder().encode(MongoJob(status: MongoJobStatus.ready,
-                                                            jobid: id.string,
-                                                            queue: context.queueName.string,
-                                                            data: data,
-                                                            created: Date()))
+        try await collection.buildIndexes {
+            UniqueIndex(
+                named: "job_index",
+                field: "jobid"
+            )
             
-            return mongodb["vapor_queue"]
-            .insert(encoded)
-            .flatMap { _ in return self.context.eventLoop.future() }
-        } catch {
-            return self.context.eventLoop.makeFailedFuture(error)
+            UniqueIndex(
+                named: "queue_index",
+                field: "queue"
+            )
         }
     }
-    
-    // Mark job as completed
-    func clear(_ id: JobIdentifier) -> EventLoopFuture<Void> {
-        mongodb["vapor_queue"]
-        .findAndModify(where: ["jobid": id.string,
-                               "queue": "\(context.queueName.string)",
-                               "status": MongoJobStatus.processing.rawValue],
-                       update: ["$set": ["status": MongoJobStatus.completed.rawValue]],
-                       returnValue: .modified)
-        .execute()
-        .flatMap { reply in
-            guard reply.ok == 1 else {
-                return self.context.eventLoop.makeFailedFuture(reply)
-            }
-            return self.context.eventLoop.future()
-        }
-    }
-    
-    // Mark oldest job as processing
-    func pop() -> EventLoopFuture<JobIdentifier?> {
-        mongodb["vapor_queue"]
-        .findAndModify(where: ["queue": "\(context.queueName.string)",
-                               "status": "ready"],
-                       update: ["$set": ["status": MongoJobStatus.processing.rawValue]],
-                       returnValue: .modified)
-        .sort(["created": .ascending])
-        .execute()
-        .flatMapThrowing { reply in
-            guard reply.ok == 1, let document = reply.value else {
-                return nil
-            }
-            let job = try BSONDecoder().decode(MongoJob.self, from: document)
-            return JobIdentifier(string: job.jobid)
-        }
-    }
-    
-    // Mark jobs that can't be finished as ready and reset the created date to put it to the back of the queue.
-    func push(_ id: JobIdentifier) -> EventLoopFuture<Void> {
-        mongodb["vapor_queue"]
-        .findAndModify(where: ["jobid": id.string,
-                               "queue": "\(context.queueName.string)",
-                               "status": "processing"],
-                       update: ["$set": ["status": MongoJobStatus.ready.rawValue,
-                                         "created": Date()] as Document])
-        .execute()
-        .transform(to: ())
-    }
-}
-
-struct MongoQueuesDriver: QueuesDriver {
-    internal let database: MongoDatabase
-    
-    init(database: MongoDatabase) {
-        self.database = database
-    }
-    
-    func makeQueue(with context: QueueContext) -> Queue {
-        MongoQueue(context: context, mongodb: database)
-    }
-    
-    func shutdown() {
-    }
-}
-
-internal struct MongoJob: Codable {
-    /// The current status of the job.
-    var status: MongoJobStatus
-    /// Unique identifier of the job.
-    var jobid: String
-    /// The queue this job is currently in.
-    var queue: String
-    /// The `JobData`.
-    var data: JobData
-    /// When the job was created.
-    var created: Date
-}
-
-internal enum MongoJobStatus: String, Codable {
-    /// The job is rerady to be picked up and executed/processed.
-    case ready
-    /// The job is currently being processed.
-    case processing
-    /// The job has completed processing.
-    case completed
 }

--- a/Sources/QueuesMongoDriver/QueuesMongoError.swift
+++ b/Sources/QueuesMongoDriver/QueuesMongoError.swift
@@ -1,0 +1,6 @@
+import struct Queues.JobIdentifier
+
+enum QueuesMongoError: Error {
+    /// The queues system attempted to act on a job identifier which could not be found.
+    case missingJob(JobIdentifier)
+}

--- a/Tests/QueuesMongoDriverTests/QueuesMongoDriverTests.swift
+++ b/Tests/QueuesMongoDriverTests/QueuesMongoDriverTests.swift
@@ -1,53 +1,276 @@
-import QueuesMongoDriver
 import Queues
 import XCTVapor
 import MongoKitten
+@testable import QueuesMongoDriver
 
 final class QueuesMongoDriverTests: XCTestCase {
+    var app: Application!
     
-    func testExample() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-
-        let email = Email()
-        app.queues.add(email)
-
-        let mongoDatabase = try MongoDatabase.lazyConnect("mongodb://localhost:27017/queuesdriver",
-                                                          on: app.eventLoopGroup.next())
-        
-        try app.queues.setupMongo(using: mongoDatabase)
-        
-        app.queues.use(.mongodb(mongoDatabase))
-
-        app.get("send-email") { req in
-            req.queue.dispatch(Email.self, .init(to: "mongo@database.driver"))
-                .map { HTTPStatus.ok }
+    override func tearDown() async throws {
+        try await app?.asyncShutdown()
+        app = nil
+    }
+    
+    private func withEachDatabase(
+        preserveJobs: Bool = false,
+        collectionName: String = "queues_jobs",
+        _ closure: () async throws -> Void
+    ) async throws {
+        func run(_ url: String, _ dbName: String) async throws {
+            self.app = try await Application.make(.testing)
+            self.app.logger[metadataKey: "test-db"] = "\(dbName)"
+            
+            let mongoDatabase = try await MongoDatabase.connect(
+                to: "\(url)/\(dbName)",
+                logger: self.app.logger
+            )
+            
+            try await app.queues.setupMongo(using: mongoDatabase)
+            app.queues.use(.mongodb(
+                mongoDatabase,
+                preservesCompletedJobs: preserveJobs,
+                collectionName: collectionName
+            ))
+            
+            do { try await closure() }
+            catch {
+                try? await mongoDatabase[collectionName].drop()
+                try? await app.asyncShutdown()
+                self.app = nil
+                throw error
+            }
+            
+            try await mongoDatabase[collectionName].drop()
+            try await app.asyncShutdown()
+            self.app = nil
         }
-
-        try app.testable().test(.GET, "send-email") { res in
+        
+        try await run("mongodb://localhost:27017", "queuesdriver_test")
+    }
+    
+    func testApplication() async throws { try await self.withEachDatabase {
+        let email = Email()
+        
+        self.app.queues.add(email)
+        self.app.get("send-email") { req in
+            try await req.queue.dispatch(Email.self, .init(to: "vamsi@vapor.codes"))
+            return HTTPStatus.ok
+        }
+        
+        try await self.app.testable().test(.GET, "send-email") { res async in
             XCTAssertEqual(res.status, .ok)
         }
         
-        XCTAssertEqual(email.sent, [])
-        try app.queues.queue.worker.run().wait()
-        XCTAssertEqual(email.sent, [.init(to: "mongo@database.driver")])
-    }
-}
-
-final class Email: Job {
-    struct Message: Codable, Equatable {
-        let to: String
+        await XCTAssertEqualAsync(await email.sent, [])
+        try await self.app.queues.queue.worker.run().get()
+        await XCTAssertEqualAsync(await email.sent, [.init(to: "vamsi@vapor.codes")])
+    } }
+    
+    
+    func testFailedJobLoss() async throws { try await self.withEachDatabase {
+        let jobID = JobIdentifier()
+        
+        self.app.queues.add(FailingJob())
+        self.app.get("test") { req in
+            try await req.queue.dispatch(FailingJob.self, ["foo": "bar"], id: jobID)
+            return HTTPStatus.ok
+        }
+        
+        try await self.app.testable().test(.GET, "test") { res async in
+            XCTAssertEqual(res.status, .ok)
+        }
+        
+        await XCTAssertThrowsErrorAsync(try await self.app.queues.queue.worker.run().get()) {
+            XCTAssert($0 is FailingJob.Failure)
+        }
+        
+        // Verify the failed job still exists in MongoDB
+        guard let queue = self.app.queues.queue as? MongoQueue else {
+            XCTFail("Queue is not a MongoQueue")
+            return
+        }
+        
+        let failedJob = try await queue.collection.findOne(
+            "id" == jobID.string &&
+            "queueName" == queue.context.queueName.string &&
+            "state" == StoredJobState.processing.rawValue,
+            as: MongoJob.self
+        )
+        
+        XCTAssertNotNil(failedJob, "Failed job should still exist in database")
+    } }
+    
+    func testDelayedJobIsRemovedFromProcessingQueue() async throws { try await self.withEachDatabase {
+        let jobID = JobIdentifier()
+        
+        self.app.queues.add(DelayedJob())
+        self.app.get("delay-job") { req in
+            try await req.queue.dispatch(DelayedJob.self, .init(name: "vapor"), delayUntil: .init(timeIntervalSinceNow: 3600.0), id: jobID)
+            return HTTPStatus.ok
+        }
+        
+        try await self.app.testable().test(.GET, "delay-job") { res async in
+            XCTAssertEqual(res.status, .ok)
+        }
+        
+        // Verify the delayed job is in pending state
+        guard let queue = self.app.queues.queue as? MongoQueue else {
+            XCTFail("Queue is not a MongoQueue")
+            return
+        }
+        
+        let delayedJob = try await queue.collection.findOne(
+            "id" == jobID.string &&
+            "queueName" == queue.context.queueName.string &&
+            "state" == StoredJobState.pending.rawValue,
+            as: MongoJob.self
+        )
+        
+        XCTAssertNotNil(delayedJob, "Delayed job should exist in pending state")
+    } }
+    
+    func testJobPreservation() async throws { try await self.withEachDatabase(preserveJobs: true) {
+        let email = Email()
+        
+        self.app.queues.add(email)
+        self.app.get("send-email") { req in
+            try await req.queue.dispatch(Email.self, .init(to: "vamsi@vapor.codes"))
+            return HTTPStatus.ok
+        }
+        
+        try await self.app.testable().test(.GET, "send-email") { res async in
+            XCTAssertEqual(res.status, .ok)
+        }
+        
+        await XCTAssertEqualAsync(await email.sent, [])
+        try await self.app.queues.queue.worker.run().get()
+        await XCTAssertEqualAsync(await email.sent, [.init(to: "vamsi@vapor.codes")])
+        
+        // Verify job is preserved in MongoDB
+        guard let queue = self.app.queues.queue as? MongoQueue else {
+            XCTFail("Queue is not a MongoQueue")
+            return
+        }
+        
+        let jobCount = try await queue.collection.count(
+            "queueName" == queue.context.queueName.string &&
+            "state" == StoredJobState.completed.rawValue
+        )
+        
+        XCTAssertEqual(jobCount, 1, "Completed job should be preserved in the database")
+    } }
+    
+    func testCoverageForFailingQueue() async throws {
+        self.app = try await Application.make(.testing)
+        let queue = FailingQueue(
+            failure: QueuesMongoError.missingJob(JobIdentifier()),
+            context: .init(queueName: .default, configuration: .init(), application: self.app, logger: self.app.logger, on: self.app.eventLoopGroup.any())
+        )
+        await XCTAssertThrowsErrorAsync(try await queue.get(.init()))
+        await XCTAssertThrowsErrorAsync(try await queue.set(.init(), to: JobData(payload: [], maxRetryCount: 0, jobName: "", delayUntil: nil, queuedAt: .init())))
+        await XCTAssertThrowsErrorAsync(try await queue.clear(.init()))
+        await XCTAssertThrowsErrorAsync(try await queue.push(.init()))
+        await XCTAssertThrowsErrorAsync(try await queue.pop())
+        try await self.app.asyncShutdown()
+        self.app = nil
     }
     
-    var sent: [Message]
-    
-    init() {
-        self.sent = []
+    func testCoverageForJobModel() {
+        let date = Date()
+        let model = MongoJob(id: .init(string: "test"), queue: .init(string: "test"), jobData: .init(payload: [], maxRetryCount: 0, jobName: "", delayUntil: nil, queuedAt: date))
+        
+        XCTAssertEqual(model.id, "test")
+        XCTAssertEqual(model.queueName, "test")
+        XCTAssertEqual(model.jobName, "")
+        XCTAssertEqual(model.queuedAt, date)
+        XCTAssertNil(model.delayUntil)
+        XCTAssertEqual(model.state, .pending)
+        XCTAssertEqual(model.maxRetryCount, 0)
+        XCTAssertEqual(model.attempts, 0)
+        XCTAssertEqual(model.payload, Data())
+        XCTAssertNotNil(model.updatedAt)
     }
     
-    func dequeue(_ context: QueueContext, _ message: Message) -> EventLoopFuture<Void> {
-        self.sent.append(message)
-        context.logger.info("sending email \(message)")
-        return context.eventLoop.makeSucceededFuture(())
+    actor Email: AsyncJob {
+        struct Message: Codable, Equatable {
+            let to: String
+        }
+        
+        var sent: [Message] = []
+        
+        func dequeue(_ context: QueueContext, _ message: Message) async throws {
+            self.sent.append(message)
+            context.logger.info("sending email", metadata: ["message": "\(message)"])
+        }
+    }
+    
+    struct DelayedJob: AsyncJob {
+        struct Message: Codable, Equatable {
+            let name: String
+        }
+        
+        func dequeue(_ context: QueueContext, _ message: Message) async throws {
+            context.logger.info("Hello", metadata: ["name": "\(message.name)"])
+        }
+    }
+    
+    struct FailingJob: AsyncJob {
+        struct Failure: Error {}
+        
+        func dequeue(_ context: QueueContext, _ message: [String: String]) async throws { throw Failure() }
+        func error(_ context: QueueContext, _ error: any Error, _ payload: [String: String]) async throws { throw Failure() }
+    }
+    
+    func XCTAssertEqualAsync<T>(
+        _ expression1: @autoclosure () async throws -> T,
+        _ expression2: @autoclosure () async throws -> T,
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #filePath, line: UInt = #line
+    ) async where T: Equatable {
+        do {
+            let expr1 = try await expression1(), expr2 = try await expression2()
+            return XCTAssertEqual(expr1, expr2, message(), file: file, line: line)
+        } catch {
+            return XCTAssertEqual(try { () -> Bool in throw error }(), false, message(), file: file, line: line)
+        }
+    }
+    
+    func XCTAssertThrowsErrorAsync<T>(
+        _ expression: @autoclosure () async throws -> T,
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #filePath, line: UInt = #line,
+        _ callback: (any Error) -> Void = { _ in }
+    ) async {
+        do {
+            _ = try await expression()
+            XCTAssertThrowsError({}(), message(), file: file, line: line, callback)
+        } catch {
+            XCTAssertThrowsError(try { throw error }(), message(), file: file, line: line, callback)
+        }
+    }
+    
+    func XCTAssertNoThrowAsync<T>(
+        _ expression: @autoclosure () async throws -> T,
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #filePath, line: UInt = #line
+    ) async {
+        do {
+            _ = try await expression()
+        } catch {
+            XCTAssertNoThrow(try { throw error }(), message(), file: file, line: line)
+        }
+    }
+    
+    func XCTAssertNotNilAsync(
+        _ expression: @autoclosure () async throws -> Any?,
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #filePath, line: UInt = #line
+    ) async {
+        do {
+            let result = try await expression()
+            XCTAssertNotNil(result, message(), file: file, line: line)
+        } catch {
+            return XCTAssertNotNil(try { throw error }(), message(), file: file, line: line)
+        }
     }
 }


### PR DESCRIPTION
This PR introduces async support with `AsyncQueue`, along with features such as job preservation and customizable collection names. I’ve updated the documentation and expanded the test coverage.